### PR TITLE
[Feature] setup TabBar with 4 mock screens, grouped structure, and cu…

### DIFF
--- a/iOS-FakeNFT-Extended.xcodeproj/project.pbxproj
+++ b/iOS-FakeNFT-Extended.xcodeproj/project.pbxproj
@@ -42,6 +42,11 @@
 		C266D5E42F3F166A00B47E7C /* NavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C266D5E32F3F166A00B47E7C /* NavigationBarModifier.swift */; };
 		C25A8C262F3FBCAB00B0462E /* LikeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25A8C252F3FBCAB00B0462E /* LikeButton.swift */; };
 		C25A8C282F3FBCD300B0462E /* CartButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25A8C272F3FBCD300B0462E /* CartButton.swift */; };
+		C20076A82F3F2F3500C217BF /* MockCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20076A72F3F2F3500C217BF /* MockCatalogView.swift */; };
+		C20076AA2F3F2F7700C217BF /* MockProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20076A92F3F2F7700C217BF /* MockProfileView.swift */; };
+		C20076AC2F3F2F9700C217BF /* MockCartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20076AB2F3F2F9700C217BF /* MockCartView.swift */; };
+		C20076AE2F3F2FAD00C217BF /* MockStatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20076AD2F3F2FAD00C217BF /* MockStatisticsView.swift */; };
+		C20076C12F3F38AE00C217BF /* CustomBackgroundModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20076C02F3F38AE00C217BF /* CustomBackgroundModifier.swift */; };
 		C2E5A96E2F3C521E00632512 /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E5A96D2F3C521E00632512 /* StarRatingView.swift */; };
 		ABC5E1EB2C32084F002B4068 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = ABC5E1E92C32084F002B4068 /* Localizable.strings */; };
 		C234CDF72F388EC600E6C9EE /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C234CDF62F388EC600E6C9EE /* ProgressView.swift */; };
@@ -102,6 +107,11 @@
 		C266D5E32F3F166A00B47E7C /* NavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifier.swift; sourceTree = "<group>"; };
 		C25A8C252F3FBCAB00B0462E /* LikeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeButton.swift; sourceTree = "<group>"; };
 		C25A8C272F3FBCD300B0462E /* CartButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartButton.swift; sourceTree = "<group>"; };
+		C20076A72F3F2F3500C217BF /* MockCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCatalogView.swift; sourceTree = "<group>"; };
+		C20076A92F3F2F7700C217BF /* MockProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProfileView.swift; sourceTree = "<group>"; };
+		C20076AB2F3F2F9700C217BF /* MockCartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCartView.swift; sourceTree = "<group>"; };
+		C20076AD2F3F2FAD00C217BF /* MockStatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStatisticsView.swift; sourceTree = "<group>"; };
+		C20076C02F3F38AE00C217BF /* CustomBackgroundModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBackgroundModifier.swift; sourceTree = "<group>"; };
 		C2E5A96D2F3C521E00632512 /* StarRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; };
 		ABC5E1EA2C32084F002B4068 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C234CDF62F388EC600E6C9EE /* ProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
@@ -164,6 +174,10 @@
 		ABC5E16A2C31F5AF002B4068 /* iOS-FakeNFT-Extended */ = {
 			isa = PBXGroup;
 			children = (
+				C20076A52F3F2EDA00C217BF /* Profile */,
+				C20076A42F3F2ED000C217BF /* Catalog */,
+				C20076A32F3F2E9C00C217BF /* Cart */,
+				C20076A62F3F2EE200C217BF /* Statistics */,
 				C234CF532F38A8ED00E6C9EE /* Resources */,
 				ABC5E16B2C31F5AF002B4068 /* iOS_FakeNFT_ExtendedApp.swift */,
 				ABC5E1952C31F64A002B4068 /* DesignSystem */,
@@ -318,6 +332,38 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		C20076A32F3F2E9C00C217BF /* Cart */ = {
+			isa = PBXGroup;
+			children = (
+				C20076AB2F3F2F9700C217BF /* MockCartView.swift */,
+			);
+			path = Cart;
+			sourceTree = "<group>";
+		};
+		C20076A42F3F2ED000C217BF /* Catalog */ = {
+			isa = PBXGroup;
+			children = (
+				C20076A72F3F2F3500C217BF /* MockCatalogView.swift */,
+			);
+			path = Catalog;
+			sourceTree = "<group>";
+		};
+		C20076A52F3F2EDA00C217BF /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				C20076A92F3F2F7700C217BF /* MockProfileView.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		C20076A62F3F2EE200C217BF /* Statistics */ = {
+			isa = PBXGroup;
+			children = (
+				C20076AD2F3F2FAD00C217BF /* MockStatisticsView.swift */,
+			);
+			path = Statistics;
+			sourceTree = "<group>";
+		};
 		EA3CE9BB2F387D69005CFF7D /* UIElements */ = {
 			isa = PBXGroup;
 			children = (
@@ -327,6 +373,7 @@
 				C234CDF62F388EC600E6C9EE /* ProgressView.swift */,
 				C25A8C252F3FBCAB00B0462E /* LikeButton.swift */,
 				C25A8C272F3FBCD300B0462E /* CartButton.swift */,
+				C20076C02F3F38AE00C217BF /* CustomBackgroundModifier.swift */,
 			);
 			path = UIElements;
 			sourceTree = "<group>";
@@ -501,17 +548,21 @@
 				ABC5E19D2C31F6A6002B4068 /* NftStorage.swift in Sources */,
 				ABC5E1E82C320610002B4068 /* NftDetailBridgeView.swift in Sources */,
 				ABC5E1E62C320585002B4068 /* LinePageControl.swift in Sources */,
+				C20076AA2F3F2F7700C217BF /* MockProfileView.swift in Sources */,
+				C20076AE2F3F2FAD00C217BF /* MockStatisticsView.swift in Sources */,
 				ABC5E1DD2C3204DC002B4068 /* CellsReusingUtils.swift in Sources */,
 				ABC5E1B52C31FC57002B4068 /* TabBarView.swift in Sources */,
 				ABC5E1E42C32055B002B4068 /* ErrorView.swift in Sources */,
 				ABC5E1A62C31F815002B4068 /* NetworkRequest.swift in Sources */,
 				ABC5E1D52C320446002B4068 /* NftDetailInput.swift in Sources */,
 				ABC5E16E2C31F5AF002B4068 /* ContentView.swift in Sources */,
+				C20076A82F3F2F3500C217BF /* MockCatalogView.swift in Sources */,
 				ABC5E1B92C31FD51002B4068 /* TestCatalogView.swift in Sources */,
 				ABC5E1DF2C3204FB002B4068 /* LoadingView.swift in Sources */,
 				C234CDF72F388EC600E6C9EE /* ProgressView.swift in Sources */,
-				ABC5E1972C31F656002B4068 /* Colors.swift in Sources */,
 				C25A8C262F3FBCAB00B0462E /* LikeButton.swift in Sources */,
+				C20076AC2F3F2F9700C217BF /* MockCartView.swift in Sources */,
+				C20076C12F3F38AE00C217BF /* CustomBackgroundModifier.swift in Sources */,
 				ABC5E1A42C31F800002B4068 /* NetworkClient.swift in Sources */,
 				C25A8C282F3FBCD300B0462E /* CartButton.swift in Sources */,
 				ABC5E1D32C320438002B4068 /* NftDetailAssembly.swift in Sources */,

--- a/iOS-FakeNFT-Extended/Cart/MockCartView.swift
+++ b/iOS-FakeNFT-Extended/Cart/MockCartView.swift
@@ -1,0 +1,18 @@
+//
+//  MockCartView.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Bogdan Kalitenko on 13.02.2026.
+//
+
+import SwiftUI
+
+struct MockCartView: View {
+    var body: some View {
+        Text(L10n.TabBar.cart)
+    }
+}
+
+#Preview {
+    MockCartView()
+}

--- a/iOS-FakeNFT-Extended/Catalog/MockCatalogView.swift
+++ b/iOS-FakeNFT-Extended/Catalog/MockCatalogView.swift
@@ -1,0 +1,18 @@
+//
+//  MockCatalogView.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Bogdan Kalitenko on 13.02.2026.
+//
+
+import SwiftUI
+
+struct MockCatalogView: View {
+    var body: some View {
+        Text(L10n.TabBar.catalog)
+    }
+}
+
+#Preview {
+    MockCatalogView()
+}

--- a/iOS-FakeNFT-Extended/Profile/MockProfileView.swift
+++ b/iOS-FakeNFT-Extended/Profile/MockProfileView.swift
@@ -1,0 +1,18 @@
+//
+//  MockProfileView.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Bogdan Kalitenko on 13.02.2026.
+//
+
+import SwiftUI
+
+struct MockProfileView: View {
+    var body: some View {
+        Text(L10n.TabBar.profile)
+    }
+}
+
+#Preview {
+    MockProfileView()
+}

--- a/iOS-FakeNFT-Extended/Resources/Assets.xcassets/Colors/AppSeparator.colorset/Contents.json
+++ b/iOS-FakeNFT-Extended/Resources/Assets.xcassets/Colors/AppSeparator.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x44",
+          "green" : "0x3E",
+          "red" : "0x3E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS-FakeNFT-Extended/Statistics/MockStatisticsView.swift
+++ b/iOS-FakeNFT-Extended/Statistics/MockStatisticsView.swift
@@ -1,0 +1,18 @@
+//
+//  MockStatisticsView.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Bogdan Kalitenko on 13.02.2026.
+//
+
+import SwiftUI
+
+struct MockStatisticsView: View {
+    var body: some View {
+        Text(L10n.TabBar.statistics)
+    }
+}
+
+#Preview {
+    MockStatisticsView()
+}

--- a/iOS-FakeNFT-Extended/UI/TabBarView.swift
+++ b/iOS-FakeNFT-Extended/UI/TabBarView.swift
@@ -1,16 +1,68 @@
 import SwiftUI
 
 struct TabBarView: View {
-    var body: some View {
-        TabView {
-            TestCatalogView()
-                .tabItem {
-                    Label(
-                        L10n.TabBar.catalog,
-                        systemImage: "square.stack.3d.up.fill"
-                    )
-                }
-                .backgroundStyle(.background)
+    
+    init() {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor.appBackground
+        
+        appearance.stackedLayoutAppearance.selected.iconColor = .appBlue
+        appearance.stackedLayoutAppearance.selected.titleTextAttributes = [.foregroundColor: UIColor.appBlue]
+        
+        appearance.stackedLayoutAppearance.normal.iconColor = .appTextPrimary
+        appearance.stackedLayoutAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.appTextPrimary]
+        
+        appearance.shadowColor = .appSeparator
+        
+        UITabBar.appearance().standardAppearance = appearance
+        if #available(iOS 15.0, *) {
+            UITabBar.appearance().scrollEdgeAppearance = appearance
         }
     }
+    
+    var body: some View {
+        TabView {
+            MockProfileView()
+                .customBackground(color: .purple)
+                .tabItem {
+                    Label {
+                        Text(L10n.TabBar.profile)
+                    } icon: {
+                        Image(systemName: "person.crop.circle.fill")
+                    }
+                }
+            MockCatalogView()
+                .customBackground(color: .pink)
+                .tabItem {
+                    Label {
+                        Text(L10n.TabBar.catalog)
+                    } icon: {
+                        Image(systemName: "rectangle.stack.fill")
+                    }
+                }
+            MockCartView()
+                .customBackground(color: .indigo)
+                .tabItem {
+                    Label {
+                        Text(L10n.TabBar.cart)
+                    } icon: {
+                        Image(.cart)
+                    }
+                }
+            MockStatisticsView()
+                .customBackground(color: .cyan)
+                .tabItem {
+                    Label {
+                        Text(L10n.TabBar.statistics)
+                    } icon: {
+                        Image(systemName: "flag.2.crossed.fill")
+                    }
+                }
+        }
+    }
+}
+
+#Preview {
+    TabBarView()
 }

--- a/iOS-FakeNFT-Extended/UI/UIElements/CustomBackgroundModifier.swift
+++ b/iOS-FakeNFT-Extended/UI/UIElements/CustomBackgroundModifier.swift
@@ -1,0 +1,73 @@
+//
+//  CustomBackgroundModifier.swift
+//  iOS-FakeNFT-Extended
+//
+//  Created by Bogdan Kalitenko on 13.02.2026.
+//
+
+import SwiftUI
+
+struct CustomBackgroundModifier: ViewModifier {
+    
+    let color: Color
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            Color(color).ignoresSafeArea()
+            content
+        }
+    }
+}
+
+extension View {
+    func customBackground(color: Color = .appBackground) -> some View {
+        modifier(CustomBackgroundModifier(color: color))
+    }
+}
+
+#Preview("Применение по умолчанию") {
+    VStack {
+        Text("Применение по умолчанию")
+            .padding()
+        
+        List(0..<5) { number in
+            Text("Item \(number)")
+                .listRowBackground(Color.clear)
+        }
+        .listStyle(.plain)
+        .frame(height: 200)
+    }
+    .customBackground()
+}
+
+#Preview("Применение с цветом") {
+    VStack {
+        Text("Применение с цветом")
+            .padding()
+        
+        List(["Apple", "Banana", "Cherry"], id: \.self) { fruit in
+            Text(fruit)
+                .listRowBackground(Color.clear)
+        }
+        .listStyle(.plain)
+        .frame(height: 200)
+    }
+    .customBackground(color: .red)
+}
+
+#Preview("Применение для стиля insetGrouped и настройкой разных цветов") {
+    VStack {
+        Text("Применение с цветом")
+            .padding()
+        
+        List(["Apple", "Banana", "Cherry"], id: \.self) { fruit in
+            Text(fruit)
+                .listRowBackground(Color.yellow)
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(.blue)
+        .frame(height: 200)
+    }
+    .customBackground(color: .red)
+}


### PR DESCRIPTION
## Что сделано
- Настроен внешний вид TabBar
- Добавлены заглушки экранов
- Добавлен кастомный модификатор для background (в preview примеры использования с List)

## Скриншоты (если UI)
TabBar
<img width="496" height="144" alt="image" src="https://github.com/user-attachments/assets/229ca07d-6355-4d53-8ff1-34eb499ef6f8" />
<img width="496" height="144" alt="image" src="https://github.com/user-attachments/assets/2767b97f-552c-4de6-9371-802178419756" />


Модификатор
<img width="404" height="199" alt="image" src="https://github.com/user-attachments/assets/582583b3-caee-4907-ace4-3ab4156719ec" />


## Чеклист
- [x] Код собирается и запускается в Xcode
- [x] Нет ворнингов
- [x] Поддержка превью в разных стейтах (если UI)

## Ссылка на задачу/issue
Closes #61 
